### PR TITLE
Use internal Firebase dependencies to limit size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
       "version": "0.0.1-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "firebase": "^10.12.3",
+        "@firebase/app": "0.10.6",
+        "@firebase/auth": "1.7.5",
+        "@firebase/database": "1.0.6",
+        "@firebase/firestore": "^4.6.4",
         "firebase-admin": "^12.2.0",
         "tiny-typed-emitter": "^2.1.0"
       },
@@ -29,9 +32,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
-      "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
+      "integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -168,44 +171,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@firebase/analytics": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.5.tgz",
-      "integrity": "sha512-d0X2ksTOKHMf5zFAMKFZWXa8hSbgohsG507xFsGhF4Uet2b8uEUL/YLrEth67jXEbGEi1UQZX4AaGBxKNiDzjw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.8",
-        "@firebase/installations": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/analytics-compat": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.11.tgz",
-      "integrity": "sha512-wmXxJ49pEY7H549Pa4CDPOTzkPJnfG2Yolptg72ntTgSrbKVq+Eg9cAQY6Z5Kn9ATSQRX5oGXKlNfEk5DJBvvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/analytics": "0.10.5",
-        "@firebase/analytics-types": "0.8.2",
-        "@firebase/component": "0.6.8",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/analytics-types": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.2.tgz",
-      "integrity": "sha512-EnzNNLh+9/sJsimsA/FGqzakmrAUKLeJvjRHlg8df1f97NLUlFidk9600y0ZgWOp3CAxn6Hjtk+08tixlUOWyw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@firebase/app": {
       "version": "0.10.6",
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.6.tgz",
@@ -219,62 +184,11 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/@firebase/app-check": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.5.tgz",
-      "integrity": "sha512-WyIckkVYAfnzsPIw6EAt/qBUANkUAVl6irF0xuJ1R9ISNyUT1h7dPAwvs/g3rsx0fpBWaHRAH0IFiN6zO6yLqQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/app-check-compat": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.12.tgz",
-      "integrity": "sha512-p/5w3pMih3JVT6u7g04KXgSZr6HDsQXyeWZkIe0+r71dPOlcKyUooe9/feTc8BWpjha3rUOkqQ7+JXZObwvYoQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/app-check": "0.8.5",
-        "@firebase/app-check-types": "0.5.2",
-        "@firebase/component": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
     "node_modules/@firebase/app-check-interop-types": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.2.tgz",
       "integrity": "sha512-LMs47Vinv2HBMZi49C09dJxp0QT5LwDzFaVGf/+ITHe3BlIhUiLNttkATSXplc89A2lAaeTqjgqVkiRfUGyQiQ==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/app-check-types": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.2.tgz",
-      "integrity": "sha512-FSOEzTzL5bLUbD2co3Zut46iyPWML6xc4x+78TeaXMSuJap5QObfb+rVvZJtla3asN4RwU7elaQaduP+HFizDA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/app-compat": {
-      "version": "0.2.36",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.36.tgz",
-      "integrity": "sha512-qsf+pllpgy1IGe2f5vfenOHSX8Cs58sVR5L6h/zBlNy9Yo54B2jy61KxLpSOgyRZb18IlnLLGjo7VtGU1CHvHA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/app": "0.10.6",
-        "@firebase/component": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      }
     },
     "node_modules/@firebase/app-types": {
       "version": "0.9.2",
@@ -304,38 +218,11 @@
         }
       }
     },
-    "node_modules/@firebase/auth-compat": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.10.tgz",
-      "integrity": "sha512-epDhgNIXmhl9DPuTW9Ec5NDJJKMFIdXBXiQI9O0xNHveow/ETtBCY86srzF7iCacqsd30CcpLwwXlhk8Y19Olg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/auth": "1.7.5",
-        "@firebase/auth-types": "0.12.2",
-        "@firebase/component": "0.6.8",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0",
-        "undici": "5.28.4"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
     "node_modules/@firebase/auth-interop-types": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.3.tgz",
       "integrity": "sha512-Fc9wuJGgxoxQeavybiuwgyi+0rssr76b+nHpj+eGhXFYAdudMWyfBHvFL/I5fEHniUM/UQdFzi9VXJK2iZF7FQ==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/auth-types": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.12.2.tgz",
-      "integrity": "sha512-qsEBaRMoGvHO10unlDJhaKSuPn4pyoTtlQuP1ghZfzB6rNQPuhp/N/DcFZxm9i4v0SogjCbf9reWupwIvfmH6w==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@firebase/app-types": "0.x",
-        "@firebase/util": "1.x"
-      }
     },
     "node_modules/@firebase/component": {
       "version": "0.6.8",
@@ -408,110 +295,17 @@
         "@firebase/app": "0.x"
       }
     },
-    "node_modules/@firebase/firestore-compat": {
-      "version": "0.3.33",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.33.tgz",
-      "integrity": "sha512-i42a2l31N95CwYEB7zmfK0FS1mrO6pwOLwxavCrwu1BCFrVVVQhUheTPIda/iGguK/2Nog0RaIR1bo7QkZEz3g==",
+    "node_modules/@firebase/firestore/node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.8",
-        "@firebase/firestore": "4.6.4",
-        "@firebase/firestore-types": "3.0.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
       },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/firestore-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.2.tgz",
-      "integrity": "sha512-wp1A+t5rI2Qc/2q7r2ZpjUXkRVPtGMd6zCLsiWurjsQpqPgFin3AhNibKcIzoF2rnToNa/XYtyWXuifjOOwDgg==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@firebase/app-types": "0.x",
-        "@firebase/util": "1.x"
-      }
-    },
-    "node_modules/@firebase/functions": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.11.6.tgz",
-      "integrity": "sha512-GPfIBPtpwQvsC7SQbgaUjLTdja0CsNwMoKSgrzA1FGGRk4NX6qO7VQU6XCwBiAFWbpbQex6QWkSMsCzLx1uibQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.2",
-        "@firebase/auth-interop-types": "0.2.3",
-        "@firebase/component": "0.6.8",
-        "@firebase/messaging-interop-types": "0.2.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0",
-        "undici": "5.28.4"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/functions-compat": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.12.tgz",
-      "integrity": "sha512-r3XUb5VlITWpML46JymfJPkK6I9j4SNlO7qWIXUc0TUmkv0oAfVoiIt1F83/NuMZXaGr4YWA/794nVSy4GV8tw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.8",
-        "@firebase/functions": "0.11.6",
-        "@firebase/functions-types": "0.6.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/functions-types": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.2.tgz",
-      "integrity": "sha512-0KiJ9lZ28nS2iJJvimpY4nNccV21rkQyor5Iheu/nq8aKXJqtJdeSlZDspjPSBBiHRzo7/GMUttegnsEITqR+w==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/installations": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.8.tgz",
-      "integrity": "sha512-57V374qdb2+wT5v7+ntpLXBjZkO6WRgmAUbVkRfFTM/4t980p0FesbqTAcOIiM8U866UeuuuF8lYH70D3jM/jQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.8",
-        "@firebase/util": "1.9.7",
-        "idb": "7.1.1",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/installations-compat": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.8.tgz",
-      "integrity": "sha512-pI2q8JFHB7yIq/szmhzGSWXtOvtzl6tCUmyykv5C8vvfOVJUH6mP4M4iwjbK8S1JotKd/K70+JWyYlxgQ0Kpyw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.8",
-        "@firebase/installations": "0.6.8",
-        "@firebase/installations-types": "0.5.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/installations-types": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.2.tgz",
-      "integrity": "sha512-que84TqGRZJpJKHBlF2pkvc1YcXrtEDOVGiDjovP/a3s6W4nlbohGXEsBJo0JCeeg/UG9A+DEZVDUV9GpklUzA==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@firebase/app-types": "0.x"
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
       }
     },
     "node_modules/@firebase/logger": {
@@ -523,163 +317,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/@firebase/messaging": {
-      "version": "0.12.10",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.10.tgz",
-      "integrity": "sha512-fGbxJPKpl2DIKNJGhbk4mYPcM+qE2gl91r6xPoiol/mN88F5Ym6UeRdMVZah+pijh9WxM55alTYwXuW40r1Y2Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.8",
-        "@firebase/installations": "0.6.8",
-        "@firebase/messaging-interop-types": "0.2.2",
-        "@firebase/util": "1.9.7",
-        "idb": "7.1.1",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/messaging-compat": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.10.tgz",
-      "integrity": "sha512-FXQm7rcowkDm8kFLduHV35IRYCRo+Ng0PIp/t1+EBuEbyplaKkGjZ932pE+owf/XR+G/60ku2QRBptRGLXZydg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.8",
-        "@firebase/messaging": "0.12.10",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/messaging-interop-types": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.2.tgz",
-      "integrity": "sha512-l68HXbuD2PPzDUOFb3aG+nZj5KA3INcPwlocwLZOzPp9rFM9yeuI9YLl6DQfguTX5eAGxO0doTR+rDLDvQb5tA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/performance": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.6.8.tgz",
-      "integrity": "sha512-F+alziiIZ6Yn8FG47mxwljq+4XkgkT2uJIFRlkyViUQRLzrogaUJW6u/+6ZrePXnouKlKIwzqos3PVJraPEcCA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.8",
-        "@firebase/installations": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/performance-compat": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.8.tgz",
-      "integrity": "sha512-o7TFClRVJd3VIBoY7KZQqtCeW0PC6v9uBzM6Lfw3Nc9D7hM6OonqecYvh7NwJ6R14k+xM27frLS4BcCvFHKw2A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/performance": "0.6.8",
-        "@firebase/performance-types": "0.2.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/performance-types": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.2.tgz",
-      "integrity": "sha512-gVq0/lAClVH5STrIdKnHnCo2UcPLjJlDUoEB/tB4KM+hAeHUxWKnpT0nemUPvxZ5nbdY/pybeyMe8Cs29gEcHA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/remote-config": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.4.8.tgz",
-      "integrity": "sha512-AMLqe6wfIRnjc6FkCWOSUjhc1fSTEf8o+cv1NolFvbiJ/tU+TqN4pI7pT+MIKQzNiq5fxLehkOx+xtAQBxPJKQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.8",
-        "@firebase/installations": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/remote-config-compat": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.8.tgz",
-      "integrity": "sha512-UxSFOp6dzFj2AHB8Bq/BYtbq5iFyizKx4Rd6WxAdaKYM8cnPMeK+l2v+Oogtjae+AeyHRI+MfL2acsfVe5cd2A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/remote-config": "0.4.8",
-        "@firebase/remote-config-types": "0.3.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/remote-config-types": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.2.tgz",
-      "integrity": "sha512-0BC4+Ud7y2aPTyhXJTMTFfrGGLqdYXrUB9sJVAB8NiqJswDTc4/2qrE/yfUbnQJhbSi6ZaTTBKyG3n1nplssaA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/storage": {
-      "version": "0.12.6",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.12.6.tgz",
-      "integrity": "sha512-Zgb9WuehJxzhj7pGXUvkAEaH+3HvLjD9xSZ9nepuXf5f8378xME7oGJtREr/RnepdDA5YW0XIxe0QQBNHpe1nw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.8",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0",
-        "undici": "5.28.4"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/storage-compat": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.9.tgz",
-      "integrity": "sha512-WWgAp5bTW961oIsCc9+98m4MIVKpEqztAlIngfHfwO/x3DYoBPRl/awMRG3CAXyVxG+7B7oHC5IsnqM+vTwx2A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.8",
-        "@firebase/storage": "0.12.6",
-        "@firebase/storage-types": "0.8.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/storage-types": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.2.tgz",
-      "integrity": "sha512-0vWu99rdey0g53lA7IShoA2Lol1jfnPovzLDUBuon65K7uKG9G+L5uO05brD9pMw+l4HRFw23ah3GwTGpEav6g==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@firebase/app-types": "0.x",
-        "@firebase/util": "1.x"
-      }
-    },
     "node_modules/@firebase/util": {
       "version": "1.9.7",
       "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.7.tgz",
@@ -687,26 +324,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@firebase/vertexai-preview": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@firebase/vertexai-preview/-/vertexai-preview-0.0.3.tgz",
-      "integrity": "sha512-KVtUWLp+ScgiwkDKAvNkVucAyhLVQp6C6lhnVEuIg4mWhWcS3oerjAeVhZT4uNofKwWxRsOaB2Yec7DMTXlQPQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.2",
-        "@firebase/component": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x",
-        "@firebase/app-types": "0.x"
       }
     },
     "node_modules/@firebase/webchannel-wrapper": {
@@ -766,9 +383,9 @@
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.11.2.tgz",
-      "integrity": "sha512-jJOrKyOdujfrSF8EJODW9yY6hqO4jSTk6eVITEj2gsD43BSXuDlnMlLOaBUQhXL29VGnSkxDgYl5tlFhA6LKSA==",
+      "version": "7.11.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.11.3.tgz",
+      "integrity": "sha512-dFAR/IRENn+ZTTwBbMgoBGSrPrqNKoCEIjG7Wmq2+IpmyyjDk5BLip9HG9TUdMVRRP6xOQFrkEr7zIY1ZsoTSQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -803,16 +420,17 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.15",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
-      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "version": "1.10.11",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.11.tgz",
+      "integrity": "sha512-3RaoxOqkHHN2c05bwtBNVJmOf/UwMam0rZYtdl7dsRpsvDwcNpv6LkGgzltQ7xVf822LzBoKEPRvf4D7+xeIDw==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.8",
-        "@types/node": ">=12.12.47"
+        "@grpc/proto-loader": "^0.7.13",
+        "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
-        "node": "^8.13.0 || >=10.10.0"
+        "node": ">=12.10.0"
       }
     },
     "node_modules/@grpc/proto-loader": {
@@ -1953,9 +1571,9 @@
       "license": "MIT"
     },
     "node_modules/@types/readable-stream": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.14.tgz",
-      "integrity": "sha512-xZn/AuUbCMShGsqH/ehZtGDwQtbx00M9rZ2ENLe4tOjFZ/JFeWMhEZkk2fEe1jAUqqEAURIkFJ7Az/go8mM1/w==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.15.tgz",
+      "integrity": "sha512-oAZ3kw+kJFkEqyh7xORZOku1YAKvsFTogRY8kVl4vHpEKiDkfnSA/My8haRE7fvmix5Zyy+1pwzOi7yycGLBJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2554,9 +2172,9 @@
       }
     },
     "node_modules/bl": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.13.tgz",
-      "integrity": "sha512-tMncAcpsyjZgAVbVFupVIaB2xud13xxT59fdHkuszY2jdZkqIWfpQdmII1fOe3kOGAz0mNLTIHEm+KxpYsQKKg==",
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.14.tgz",
+      "integrity": "sha512-TJfbvGdL7KFGxTsEbsED7avqpFdY56q9IW0/aiytyheJzxST/+Io6cx/4Qx0K2/u0BPRDs65mjaQzYvMZeNocQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4074,41 +3692,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/firebase": {
-      "version": "10.12.3",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.12.3.tgz",
-      "integrity": "sha512-dO2cQ8eP6RnM2wcGzbxnoljjjMBf1suUrHYFftjSpbPn/8bEx959cwTRDHqBx3MwSzNsg6zZV/wiWydJPhUKgw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/analytics": "0.10.5",
-        "@firebase/analytics-compat": "0.2.11",
-        "@firebase/app": "0.10.6",
-        "@firebase/app-check": "0.8.5",
-        "@firebase/app-check-compat": "0.3.12",
-        "@firebase/app-compat": "0.2.36",
-        "@firebase/app-types": "0.9.2",
-        "@firebase/auth": "1.7.5",
-        "@firebase/auth-compat": "0.5.10",
-        "@firebase/database": "1.0.6",
-        "@firebase/database-compat": "1.0.6",
-        "@firebase/firestore": "4.6.4",
-        "@firebase/firestore-compat": "0.3.33",
-        "@firebase/functions": "0.11.6",
-        "@firebase/functions-compat": "0.3.12",
-        "@firebase/installations": "0.6.8",
-        "@firebase/installations-compat": "0.2.8",
-        "@firebase/messaging": "0.12.10",
-        "@firebase/messaging-compat": "0.2.10",
-        "@firebase/performance": "0.6.8",
-        "@firebase/performance-compat": "0.2.8",
-        "@firebase/remote-config": "0.4.8",
-        "@firebase/remote-config-compat": "0.2.8",
-        "@firebase/storage": "0.12.6",
-        "@firebase/storage-compat": "0.3.9",
-        "@firebase/util": "1.9.7",
-        "@firebase/vertexai-preview": "0.0.3"
-      }
-    },
     "node_modules/firebase-admin": {
       "version": "12.2.0",
       "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.2.0.tgz",
@@ -4515,20 +4098,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/google-gax/node_modules/@grpc/grpc-js": {
-      "version": "1.10.10",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.10.tgz",
-      "integrity": "sha512-HPa/K5NX6ahMoeBv15njAc/sfF4/jmiXLar9UlC2UfHFKZzsCVLc3wbe7+7qua7w9VPh2/L6EBxyAV7/E8Wftg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@grpc/proto-loader": "^0.7.13",
-        "@js-sdsl/ordered-map": "^4.4.2"
-      },
-      "engines": {
-        "node": ">=12.10.0"
       }
     },
     "node_modules/google-gax/node_modules/uuid": {
@@ -5094,16 +4663,13 @@
       "license": "ISC"
     },
     "node_modules/jackspeak": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.2.tgz",
-      "integrity": "sha512-qH3nOSj8q/8+Eg8LUPOq3C+6HWkpUioIjDsq1+D4zY91oZvpPttw8GwtF1nReRYKXl+1AORyFqtm2f5Q1SB6/Q==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": "14 >=14.21 || 16 >=16.20 || >=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5875,14 +5441,11 @@
       }
     },
     "node_modules/mqtt/node_modules/lru-cache": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.2.tgz",
-      "integrity": "sha512-voV4dDrdVZVNz84n39LFKDaRzfwhdzJ7akpyXfTMxCgRUp07U3lcJUXRlhTKP17rgt09sUzLi5iCitpEAr+6ug==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "14 || 16 || 18 || 20 || >=22"
-      }
+      "license": "ISC"
     },
     "node_modules/mqtt/node_modules/readable-stream": {
       "version": "4.5.2",
@@ -6580,14 +6143,11 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.2.tgz",
-      "integrity": "sha512-voV4dDrdVZVNz84n39LFKDaRzfwhdzJ7akpyXfTMxCgRUp07U3lcJUXRlhTKP17rgt09sUzLi5iCitpEAr+6ug==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "14 || 16 || 18 || 20 || >=22"
-      }
+      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
@@ -8332,9 +7892,9 @@
   },
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
-      "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
+      "integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.14.0"
@@ -8435,35 +7995,6 @@
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
     },
-    "@firebase/analytics": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.5.tgz",
-      "integrity": "sha512-d0X2ksTOKHMf5zFAMKFZWXa8hSbgohsG507xFsGhF4Uet2b8uEUL/YLrEth67jXEbGEi1UQZX4AaGBxKNiDzjw==",
-      "requires": {
-        "@firebase/component": "0.6.8",
-        "@firebase/installations": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@firebase/analytics-compat": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.11.tgz",
-      "integrity": "sha512-wmXxJ49pEY7H549Pa4CDPOTzkPJnfG2Yolptg72ntTgSrbKVq+Eg9cAQY6Z5Kn9ATSQRX5oGXKlNfEk5DJBvvA==",
-      "requires": {
-        "@firebase/analytics": "0.10.5",
-        "@firebase/analytics-types": "0.8.2",
-        "@firebase/component": "0.6.8",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@firebase/analytics-types": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.2.tgz",
-      "integrity": "sha512-EnzNNLh+9/sJsimsA/FGqzakmrAUKLeJvjRHlg8df1f97NLUlFidk9600y0ZgWOp3CAxn6Hjtk+08tixlUOWyw=="
-    },
     "@firebase/app": {
       "version": "0.10.6",
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.6.tgz",
@@ -8476,51 +8007,10 @@
         "tslib": "^2.1.0"
       }
     },
-    "@firebase/app-check": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.5.tgz",
-      "integrity": "sha512-WyIckkVYAfnzsPIw6EAt/qBUANkUAVl6irF0xuJ1R9ISNyUT1h7dPAwvs/g3rsx0fpBWaHRAH0IFiN6zO6yLqQ==",
-      "requires": {
-        "@firebase/component": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@firebase/app-check-compat": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.12.tgz",
-      "integrity": "sha512-p/5w3pMih3JVT6u7g04KXgSZr6HDsQXyeWZkIe0+r71dPOlcKyUooe9/feTc8BWpjha3rUOkqQ7+JXZObwvYoQ==",
-      "requires": {
-        "@firebase/app-check": "0.8.5",
-        "@firebase/app-check-types": "0.5.2",
-        "@firebase/component": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      }
-    },
     "@firebase/app-check-interop-types": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.2.tgz",
       "integrity": "sha512-LMs47Vinv2HBMZi49C09dJxp0QT5LwDzFaVGf/+ITHe3BlIhUiLNttkATSXplc89A2lAaeTqjgqVkiRfUGyQiQ=="
-    },
-    "@firebase/app-check-types": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.2.tgz",
-      "integrity": "sha512-FSOEzTzL5bLUbD2co3Zut46iyPWML6xc4x+78TeaXMSuJap5QObfb+rVvZJtla3asN4RwU7elaQaduP+HFizDA=="
-    },
-    "@firebase/app-compat": {
-      "version": "0.2.36",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.36.tgz",
-      "integrity": "sha512-qsf+pllpgy1IGe2f5vfenOHSX8Cs58sVR5L6h/zBlNy9Yo54B2jy61KxLpSOgyRZb18IlnLLGjo7VtGU1CHvHA==",
-      "requires": {
-        "@firebase/app": "0.10.6",
-        "@firebase/component": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      }
     },
     "@firebase/app-types": {
       "version": "0.9.2",
@@ -8539,29 +8029,10 @@
         "undici": "5.28.4"
       }
     },
-    "@firebase/auth-compat": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.10.tgz",
-      "integrity": "sha512-epDhgNIXmhl9DPuTW9Ec5NDJJKMFIdXBXiQI9O0xNHveow/ETtBCY86srzF7iCacqsd30CcpLwwXlhk8Y19Olg==",
-      "requires": {
-        "@firebase/auth": "1.7.5",
-        "@firebase/auth-types": "0.12.2",
-        "@firebase/component": "0.6.8",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0",
-        "undici": "5.28.4"
-      }
-    },
     "@firebase/auth-interop-types": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.3.tgz",
       "integrity": "sha512-Fc9wuJGgxoxQeavybiuwgyi+0rssr76b+nHpj+eGhXFYAdudMWyfBHvFL/I5fEHniUM/UQdFzi9VXJK2iZF7FQ=="
-    },
-    "@firebase/auth-types": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.12.2.tgz",
-      "integrity": "sha512-qsEBaRMoGvHO10unlDJhaKSuPn4pyoTtlQuP1ghZfzB6rNQPuhp/N/DcFZxm9i4v0SogjCbf9reWupwIvfmH6w==",
-      "requires": {}
     },
     "@firebase/component": {
       "version": "0.6.8",
@@ -8621,85 +8092,18 @@
         "@grpc/proto-loader": "^0.7.8",
         "tslib": "^2.1.0",
         "undici": "5.28.4"
+      },
+      "dependencies": {
+        "@grpc/grpc-js": {
+          "version": "1.9.15",
+          "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+          "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+          "requires": {
+            "@grpc/proto-loader": "^0.7.8",
+            "@types/node": ">=12.12.47"
+          }
+        }
       }
-    },
-    "@firebase/firestore-compat": {
-      "version": "0.3.33",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.33.tgz",
-      "integrity": "sha512-i42a2l31N95CwYEB7zmfK0FS1mrO6pwOLwxavCrwu1BCFrVVVQhUheTPIda/iGguK/2Nog0RaIR1bo7QkZEz3g==",
-      "requires": {
-        "@firebase/component": "0.6.8",
-        "@firebase/firestore": "4.6.4",
-        "@firebase/firestore-types": "3.0.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@firebase/firestore-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.2.tgz",
-      "integrity": "sha512-wp1A+t5rI2Qc/2q7r2ZpjUXkRVPtGMd6zCLsiWurjsQpqPgFin3AhNibKcIzoF2rnToNa/XYtyWXuifjOOwDgg==",
-      "requires": {}
-    },
-    "@firebase/functions": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.11.6.tgz",
-      "integrity": "sha512-GPfIBPtpwQvsC7SQbgaUjLTdja0CsNwMoKSgrzA1FGGRk4NX6qO7VQU6XCwBiAFWbpbQex6QWkSMsCzLx1uibQ==",
-      "requires": {
-        "@firebase/app-check-interop-types": "0.3.2",
-        "@firebase/auth-interop-types": "0.2.3",
-        "@firebase/component": "0.6.8",
-        "@firebase/messaging-interop-types": "0.2.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0",
-        "undici": "5.28.4"
-      }
-    },
-    "@firebase/functions-compat": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.12.tgz",
-      "integrity": "sha512-r3XUb5VlITWpML46JymfJPkK6I9j4SNlO7qWIXUc0TUmkv0oAfVoiIt1F83/NuMZXaGr4YWA/794nVSy4GV8tw==",
-      "requires": {
-        "@firebase/component": "0.6.8",
-        "@firebase/functions": "0.11.6",
-        "@firebase/functions-types": "0.6.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@firebase/functions-types": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.2.tgz",
-      "integrity": "sha512-0KiJ9lZ28nS2iJJvimpY4nNccV21rkQyor5Iheu/nq8aKXJqtJdeSlZDspjPSBBiHRzo7/GMUttegnsEITqR+w=="
-    },
-    "@firebase/installations": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.8.tgz",
-      "integrity": "sha512-57V374qdb2+wT5v7+ntpLXBjZkO6WRgmAUbVkRfFTM/4t980p0FesbqTAcOIiM8U866UeuuuF8lYH70D3jM/jQ==",
-      "requires": {
-        "@firebase/component": "0.6.8",
-        "@firebase/util": "1.9.7",
-        "idb": "7.1.1",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@firebase/installations-compat": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.8.tgz",
-      "integrity": "sha512-pI2q8JFHB7yIq/szmhzGSWXtOvtzl6tCUmyykv5C8vvfOVJUH6mP4M4iwjbK8S1JotKd/K70+JWyYlxgQ0Kpyw==",
-      "requires": {
-        "@firebase/component": "0.6.8",
-        "@firebase/installations": "0.6.8",
-        "@firebase/installations-types": "0.5.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@firebase/installations-types": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.2.tgz",
-      "integrity": "sha512-que84TqGRZJpJKHBlF2pkvc1YcXrtEDOVGiDjovP/a3s6W4nlbohGXEsBJo0JCeeg/UG9A+DEZVDUV9GpklUzA==",
-      "requires": {}
     },
     "@firebase/logger": {
       "version": "0.4.2",
@@ -8709,141 +8113,11 @@
         "tslib": "^2.1.0"
       }
     },
-    "@firebase/messaging": {
-      "version": "0.12.10",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.10.tgz",
-      "integrity": "sha512-fGbxJPKpl2DIKNJGhbk4mYPcM+qE2gl91r6xPoiol/mN88F5Ym6UeRdMVZah+pijh9WxM55alTYwXuW40r1Y2Q==",
-      "requires": {
-        "@firebase/component": "0.6.8",
-        "@firebase/installations": "0.6.8",
-        "@firebase/messaging-interop-types": "0.2.2",
-        "@firebase/util": "1.9.7",
-        "idb": "7.1.1",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@firebase/messaging-compat": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.10.tgz",
-      "integrity": "sha512-FXQm7rcowkDm8kFLduHV35IRYCRo+Ng0PIp/t1+EBuEbyplaKkGjZ932pE+owf/XR+G/60ku2QRBptRGLXZydg==",
-      "requires": {
-        "@firebase/component": "0.6.8",
-        "@firebase/messaging": "0.12.10",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@firebase/messaging-interop-types": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.2.tgz",
-      "integrity": "sha512-l68HXbuD2PPzDUOFb3aG+nZj5KA3INcPwlocwLZOzPp9rFM9yeuI9YLl6DQfguTX5eAGxO0doTR+rDLDvQb5tA=="
-    },
-    "@firebase/performance": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.6.8.tgz",
-      "integrity": "sha512-F+alziiIZ6Yn8FG47mxwljq+4XkgkT2uJIFRlkyViUQRLzrogaUJW6u/+6ZrePXnouKlKIwzqos3PVJraPEcCA==",
-      "requires": {
-        "@firebase/component": "0.6.8",
-        "@firebase/installations": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@firebase/performance-compat": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.8.tgz",
-      "integrity": "sha512-o7TFClRVJd3VIBoY7KZQqtCeW0PC6v9uBzM6Lfw3Nc9D7hM6OonqecYvh7NwJ6R14k+xM27frLS4BcCvFHKw2A==",
-      "requires": {
-        "@firebase/component": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/performance": "0.6.8",
-        "@firebase/performance-types": "0.2.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@firebase/performance-types": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.2.tgz",
-      "integrity": "sha512-gVq0/lAClVH5STrIdKnHnCo2UcPLjJlDUoEB/tB4KM+hAeHUxWKnpT0nemUPvxZ5nbdY/pybeyMe8Cs29gEcHA=="
-    },
-    "@firebase/remote-config": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.4.8.tgz",
-      "integrity": "sha512-AMLqe6wfIRnjc6FkCWOSUjhc1fSTEf8o+cv1NolFvbiJ/tU+TqN4pI7pT+MIKQzNiq5fxLehkOx+xtAQBxPJKQ==",
-      "requires": {
-        "@firebase/component": "0.6.8",
-        "@firebase/installations": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@firebase/remote-config-compat": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.8.tgz",
-      "integrity": "sha512-UxSFOp6dzFj2AHB8Bq/BYtbq5iFyizKx4Rd6WxAdaKYM8cnPMeK+l2v+Oogtjae+AeyHRI+MfL2acsfVe5cd2A==",
-      "requires": {
-        "@firebase/component": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/remote-config": "0.4.8",
-        "@firebase/remote-config-types": "0.3.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@firebase/remote-config-types": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.2.tgz",
-      "integrity": "sha512-0BC4+Ud7y2aPTyhXJTMTFfrGGLqdYXrUB9sJVAB8NiqJswDTc4/2qrE/yfUbnQJhbSi6ZaTTBKyG3n1nplssaA=="
-    },
-    "@firebase/storage": {
-      "version": "0.12.6",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.12.6.tgz",
-      "integrity": "sha512-Zgb9WuehJxzhj7pGXUvkAEaH+3HvLjD9xSZ9nepuXf5f8378xME7oGJtREr/RnepdDA5YW0XIxe0QQBNHpe1nw==",
-      "requires": {
-        "@firebase/component": "0.6.8",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0",
-        "undici": "5.28.4"
-      }
-    },
-    "@firebase/storage-compat": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.9.tgz",
-      "integrity": "sha512-WWgAp5bTW961oIsCc9+98m4MIVKpEqztAlIngfHfwO/x3DYoBPRl/awMRG3CAXyVxG+7B7oHC5IsnqM+vTwx2A==",
-      "requires": {
-        "@firebase/component": "0.6.8",
-        "@firebase/storage": "0.12.6",
-        "@firebase/storage-types": "0.8.2",
-        "@firebase/util": "1.9.7",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@firebase/storage-types": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.2.tgz",
-      "integrity": "sha512-0vWu99rdey0g53lA7IShoA2Lol1jfnPovzLDUBuon65K7uKG9G+L5uO05brD9pMw+l4HRFw23ah3GwTGpEav6g==",
-      "requires": {}
-    },
     "@firebase/util": {
       "version": "1.9.7",
       "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.7.tgz",
       "integrity": "sha512-fBVNH/8bRbYjqlbIhZ+lBtdAAS4WqZumx03K06/u7fJSpz1TGjEMm1ImvKD47w+xaFKIP2ori6z8BrbakRfjJA==",
       "requires": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "@firebase/vertexai-preview": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@firebase/vertexai-preview/-/vertexai-preview-0.0.3.tgz",
-      "integrity": "sha512-KVtUWLp+ScgiwkDKAvNkVucAyhLVQp6C6lhnVEuIg4mWhWcS3oerjAeVhZT4uNofKwWxRsOaB2Yec7DMTXlQPQ==",
-      "requires": {
-        "@firebase/app-check-interop-types": "0.3.2",
-        "@firebase/component": "0.6.8",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.7",
         "tslib": "^2.1.0"
       }
     },
@@ -8887,9 +8161,9 @@
       "optional": true
     },
     "@google-cloud/storage": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.11.2.tgz",
-      "integrity": "sha512-jJOrKyOdujfrSF8EJODW9yY6hqO4jSTk6eVITEj2gsD43BSXuDlnMlLOaBUQhXL29VGnSkxDgYl5tlFhA6LKSA==",
+      "version": "7.11.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.11.3.tgz",
+      "integrity": "sha512-dFAR/IRENn+ZTTwBbMgoBGSrPrqNKoCEIjG7Wmq2+IpmyyjDk5BLip9HG9TUdMVRRP6xOQFrkEr7zIY1ZsoTSQ==",
       "optional": true,
       "requires": {
         "@google-cloud/paginator": "^5.0.0",
@@ -8918,12 +8192,13 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.9.15",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
-      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "version": "1.10.11",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.11.tgz",
+      "integrity": "sha512-3RaoxOqkHHN2c05bwtBNVJmOf/UwMam0rZYtdl7dsRpsvDwcNpv6LkGgzltQ7xVf822LzBoKEPRvf4D7+xeIDw==",
+      "optional": true,
       "requires": {
-        "@grpc/proto-loader": "^0.7.8",
-        "@types/node": ">=12.12.47"
+        "@grpc/proto-loader": "^0.7.13",
+        "@js-sdsl/ordered-map": "^4.4.2"
       }
     },
     "@grpc/proto-loader": {
@@ -9735,9 +9010,9 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "@types/readable-stream": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.14.tgz",
-      "integrity": "sha512-xZn/AuUbCMShGsqH/ehZtGDwQtbx00M9rZ2ENLe4tOjFZ/JFeWMhEZkk2fEe1jAUqqEAURIkFJ7Az/go8mM1/w==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.15.tgz",
+      "integrity": "sha512-oAZ3kw+kJFkEqyh7xORZOku1YAKvsFTogRY8kVl4vHpEKiDkfnSA/My8haRE7fvmix5Zyy+1pwzOi7yycGLBJw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -10132,9 +9407,9 @@
       "dev": true
     },
     "bl": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.13.tgz",
-      "integrity": "sha512-tMncAcpsyjZgAVbVFupVIaB2xud13xxT59fdHkuszY2jdZkqIWfpQdmII1fOe3kOGAz0mNLTIHEm+KxpYsQKKg==",
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.14.tgz",
+      "integrity": "sha512-TJfbvGdL7KFGxTsEbsED7avqpFdY56q9IW0/aiytyheJzxST/+Io6cx/4Qx0K2/u0BPRDs65mjaQzYvMZeNocQ==",
       "dev": true,
       "requires": {
         "@types/readable-stream": "^4.0.0",
@@ -11214,40 +10489,6 @@
         "path-exists": "^4.0.0"
       }
     },
-    "firebase": {
-      "version": "10.12.3",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.12.3.tgz",
-      "integrity": "sha512-dO2cQ8eP6RnM2wcGzbxnoljjjMBf1suUrHYFftjSpbPn/8bEx959cwTRDHqBx3MwSzNsg6zZV/wiWydJPhUKgw==",
-      "requires": {
-        "@firebase/analytics": "0.10.5",
-        "@firebase/analytics-compat": "0.2.11",
-        "@firebase/app": "0.10.6",
-        "@firebase/app-check": "0.8.5",
-        "@firebase/app-check-compat": "0.3.12",
-        "@firebase/app-compat": "0.2.36",
-        "@firebase/app-types": "0.9.2",
-        "@firebase/auth": "1.7.5",
-        "@firebase/auth-compat": "0.5.10",
-        "@firebase/database": "1.0.6",
-        "@firebase/database-compat": "1.0.6",
-        "@firebase/firestore": "4.6.4",
-        "@firebase/firestore-compat": "0.3.33",
-        "@firebase/functions": "0.11.6",
-        "@firebase/functions-compat": "0.3.12",
-        "@firebase/installations": "0.6.8",
-        "@firebase/installations-compat": "0.2.8",
-        "@firebase/messaging": "0.12.10",
-        "@firebase/messaging-compat": "0.2.10",
-        "@firebase/performance": "0.6.8",
-        "@firebase/performance-compat": "0.2.8",
-        "@firebase/remote-config": "0.4.8",
-        "@firebase/remote-config-compat": "0.2.8",
-        "@firebase/storage": "0.12.6",
-        "@firebase/storage-compat": "0.3.9",
-        "@firebase/util": "1.9.7",
-        "@firebase/vertexai-preview": "0.0.3"
-      }
-    },
     "firebase-admin": {
       "version": "12.2.0",
       "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.2.0.tgz",
@@ -11519,16 +10760,6 @@
         "uuid": "^9.0.1"
       },
       "dependencies": {
-        "@grpc/grpc-js": {
-          "version": "1.10.10",
-          "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.10.tgz",
-          "integrity": "sha512-HPa/K5NX6ahMoeBv15njAc/sfF4/jmiXLar9UlC2UfHFKZzsCVLc3wbe7+7qua7w9VPh2/L6EBxyAV7/E8Wftg==",
-          "optional": true,
-          "requires": {
-            "@grpc/proto-loader": "^0.7.13",
-            "@js-sdsl/ordered-map": "^4.4.2"
-          }
-        },
         "uuid": {
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -11888,9 +11119,9 @@
       "dev": true
     },
     "jackspeak": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.2.tgz",
-      "integrity": "sha512-qH3nOSj8q/8+Eg8LUPOq3C+6HWkpUioIjDsq1+D4zY91oZvpPttw8GwtF1nReRYKXl+1AORyFqtm2f5Q1SB6/Q==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "requires": {
         "@isaacs/cliui": "^8.0.2",
@@ -12447,9 +11678,9 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "10.4.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.2.tgz",
-          "integrity": "sha512-voV4dDrdVZVNz84n39LFKDaRzfwhdzJ7akpyXfTMxCgRUp07U3lcJUXRlhTKP17rgt09sUzLi5iCitpEAr+6ug==",
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
           "dev": true
         },
         "readable-stream": {
@@ -12945,9 +12176,9 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "10.4.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.2.tgz",
-          "integrity": "sha512-voV4dDrdVZVNz84n39LFKDaRzfwhdzJ7akpyXfTMxCgRUp07U3lcJUXRlhTKP17rgt09sUzLi5iCitpEAr+6ug==",
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,10 @@
     "version": ">=1.3.7"
   },
   "dependencies": {
-    "firebase": "^10.12.3",
+    "@firebase/app": "0.10.6",
+    "@firebase/auth": "1.7.5",
+    "@firebase/database": "1.0.6",
+    "@firebase/firestore": "^4.6.4",
     "firebase-admin": "^12.2.0",
     "tiny-typed-emitter": "^2.1.0"
   },

--- a/src/lib/firebase/app/app.ts
+++ b/src/lib/firebase/app/app.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { deleteApp, FirebaseApp, FirebaseOptions, initializeApp } from "firebase/app";
+import { deleteApp, FirebaseApp, FirebaseOptions, initializeApp } from "@firebase/app";
 
 export class App {
 	private _app: FirebaseApp;

--- a/src/lib/firebase/client/client.ts
+++ b/src/lib/firebase/client/client.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { FirebaseApp, FirebaseError } from "firebase/app";
+import { FirebaseApp, FirebaseError } from "@firebase/app";
 import {
 	Auth,
 	UserCredential,
@@ -26,7 +26,7 @@ import {
 	signInWithCustomToken,
 	signInWithEmailAndPassword,
 	signOut,
-} from "firebase/auth";
+} from "@firebase/auth";
 import { App as FirebaseAdminApp, AppOptions, cert } from "firebase-admin/app";
 import { TypedEmitter } from "tiny-typed-emitter";
 import { ClientError } from "./error";

--- a/src/lib/firebase/client/error.ts
+++ b/src/lib/firebase/client/error.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-import { FirebaseError } from "firebase/app";
+import { FirebaseError } from "@firebase/app";
 
-export { FirebaseError } from "firebase/app";
+export { FirebaseError } from "@firebase/app";
 
 export function isFirebaseError(error: unknown): error is FirebaseError {
 	return (

--- a/src/lib/firebase/client/types.ts
+++ b/src/lib/firebase/client/types.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import { FirebaseOptions } from "firebase/app";
-import { UserCredential } from "firebase/auth";
+import { FirebaseOptions } from "@firebase/app";
+import { UserCredential } from "@firebase/auth";
 import { AppOptions } from "firebase-admin";
 
 export type AppConfig = Omit<AppOptions, "credential" | "serviceAccountId"> | FirebaseOptions;

--- a/src/lib/firebase/firestore/firestore.ts
+++ b/src/lib/firebase/firestore/firestore.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import { FirebaseApp } from "firebase/app";
-import { getFirestore, Firestore as Database } from "firebase/firestore";
+import { FirebaseApp } from "@firebase/app";
+import { getFirestore, Firestore as Database } from "@firebase/firestore";
 import { App } from "firebase-admin/app";
 import { getFirestore as adminGetFirestore, Firestore as AdminDatabase } from "firebase-admin/firestore";
 import { FirestoreError } from "./error";

--- a/src/lib/firebase/logger/index.ts
+++ b/src/lib/firebase/logger/index.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-export { onLog } from "firebase/app";
+export { onLog } from "@firebase/app";
 export { LogCallbackParams } from "@firebase/logger/dist/src/logger";
 
 type Level = "info" | "warn";

--- a/src/lib/firebase/rtdb/connection.ts
+++ b/src/lib/firebase/rtdb/connection.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-import { FirebaseApp } from "firebase/app";
+import { FirebaseApp } from "@firebase/app";
 import { App } from "firebase-admin/app";
-import { Database, Unsubscribe, getDatabase, onValue, ref } from "firebase/database";
+import { Database, Unsubscribe, getDatabase, onValue, ref } from "@firebase/database";
 import { Database as AdminDatabase, getDatabase as adminGetDatabase } from "firebase-admin/database";
 import { RTDBError } from "./error";
 import { Connection, ConnectionState } from "../connection";

--- a/src/lib/firebase/rtdb/rtdb.ts
+++ b/src/lib/firebase/rtdb/rtdb.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import * as database from "firebase/database";
-import { Database, get, goOffline, goOnline, onDisconnect, query, QueryConstraint, ref } from "firebase/database";
+import * as database from "@firebase/database";
+import { Database, get, goOffline, goOnline, onDisconnect, query, QueryConstraint, ref } from "@firebase/database";
 import { Database as AdminDatabase } from "firebase-admin/database";
 import { RTDBConnection } from "./connection";
 import { RTDBError } from "./error";

--- a/src/lib/firebase/rtdb/utils.ts
+++ b/src/lib/firebase/rtdb/utils.ts
@@ -16,7 +16,7 @@
  */
 
 import { DataSnapshot as AdminDataSnapshot } from "firebase-admin/database";
-import { DataSnapshot as BaseDataSnapshot } from "firebase/database";
+import { DataSnapshot as BaseDataSnapshot } from "@firebase/database";
 import { DataSnapshotType } from "./types";
 
 class DataSnapshot implements DataSnapshotType {


### PR DESCRIPTION
Using `firebase` as dependency is too heavy for installing this node on cloud platforms like FlowFuse.

The `firebase` dependency importing modules used here allows us to import them directly without risking breaking something.