### PR TITLE
Fix the value of claims must be converted with the type

### DIFF
--- a/resources/claims-container.js
+++ b/resources/claims-container.js
@@ -27,8 +27,8 @@ const FirebaseConfigClaimsContainer = (function () {
 
 				if (typeof claims !== "object") return false;
 
-				// TODO
-				for (const [k, v] of Object.entries(claims)) { }
+				// TODO: validate Claims
+				//for (const [k, v] of Object.entries(claims)) { }
 
 				return true;
 			}

--- a/src/lib/nodes/types/config.ts
+++ b/src/lib/nodes/types/config.ts
@@ -18,7 +18,7 @@ import { NodeDef } from "node-red";
 
 type AuthType = "anonymous" | "email" | "privateKey" | "customToken";
 
-type ClaimsType = Record<string, { value?: unknown; type?: unknown }>;
+type ClaimsType = Record<string, { value: string; type: "str" | "num" | "bool" | "date" | "json" }>;
 
 export type Config = NodeDef & {
 	authType?: AuthType;


### PR DESCRIPTION
Since the Claims value field is typed (TypedInput), the final value for authentication must be converted based on the field type.