### PR TITLE
Avoid warning that a config-node is unused on each deployment

### DIFF
--- a/src/lib/nodes/firebase-client.ts
+++ b/src/lib/nodes/firebase-client.ts
@@ -42,6 +42,7 @@ require("./utils");
  * @returns A FirebaseConfig Class
  */
 export class FirebaseClient {
+	private destroyUCMsgEmitted: boolean = false;
 	private globalStatus: NodeStatus = nodeStatus.disconnected;
 	private onFlowsStarted: () => void = () => this.destroyUnusedConnection();
 	/**
@@ -119,11 +120,13 @@ export class FirebaseClient {
 		const { name } = this.node.config;
 		const { rtdb, firestore } = this.statusListeners;
 
-		if (!rtdb.length && !firestore.length)
+		if (!rtdb.length && !firestore.length && !this.destroyUCMsgEmitted) {
+			this.destroyUCMsgEmitted = true;
 			this.node.warn(`WARNING: '${name}' config node is unused! All connections with Firebase will be closed...`);
+		}
 
 		// TODO: Add firestore
-		if (rtdb.length === 0 && this.node.rtdb) {
+		if (rtdb.length === 0 && this.node.rtdb && !this.node.rtdb.offline) {
 			this.node.rtdb.goOffline();
 			this.node.log("Connection with Firebase RTDB was closed because no node used.");
 		}

--- a/src/lib/nodes/firebase-client.ts
+++ b/src/lib/nodes/firebase-client.ts
@@ -390,6 +390,7 @@ export class FirebaseClient {
 	 * @remarks This method should only be used if the connection has been destroyed.
 	 */
 	private restoreDestroyedConnection() {
+		this.destroyUCMsgEmitted = false;
 		// TODO: Add firestore
 		if (this.node.rtdb?.offline) this.node.rtdb.goOnline();
 	}


### PR DESCRIPTION
The `destroyUnusedConnection` function is attached to the `flows:started` event in order to no longer use a timeout. But this function is called at each deployment which can be disturbing if a config-node has not been modified but a warning is issued each time.

With this PR, changes will only warn the user once - as the database can only be destroyed once.