### PR TITLE
Allow Firestore nodes to use RTDB connection status

### DIFF
--- a/build/nodes/firebase-config.html
+++ b/build/nodes/firebase-config.html
@@ -56,6 +56,7 @@
 				},
 				claims: { value: {}, label: i18n("label.claims"), validate: validateClaims() },
 				createUser: { value: false },
+				status: { value: { firestore: false, storage: false } },
 				useClaims: { value: false },
 			},
 			label: function () {
@@ -66,6 +67,9 @@
 
 				dropTarget.create();
 				editableClaimsList.build(this);
+
+				$("#node-config-input-firestore-status").prop("checked", this.status?.firestore || false);
+				$("#node-config-input-storage-status").prop("checked", this.status?.storage || false);
 
 				const authType = $("#node-config-input-authType");
 				const claimsContainer = $("#node-config-input-claims-container");
@@ -107,6 +111,11 @@
 
 				this.credentials.clientEmail = clientEmail.data("data") || clientEmail.val();
 				this.credentials.privateKey = privateKey.data("data") || privateKey.val();
+
+				const firestoreStatus = $("#node-config-input-firestore-status").prop("checked");
+				const storageStatus = $("#node-config-input-storage-status").prop("checked");
+
+				this.status = { firestore: firestoreStatus, storage: storageStatus };
 
 				editableClaimsList.saveItems();
 			},
@@ -239,7 +248,13 @@
 
 			<div class="form-row">
 				<label for="node-config-input-projectId"><i class="fa fa-cloud"></i> <span data-i18n="firebase-config.label.projectId"></span></label>
-				<input type="text" id="node-config-input-projectId" style="width:70%;" data-i18n="[placeholder]firebase-config.placeholder.projectId" disabled/>
+				<input type="text" id="node-config-input-projectId" style="width:70%;" data-i18n="[placeholder]firebase-config.placeholder.projectId"/>
+			</div>
+
+			<div class="form-row">
+				<label for="node-config-input-firestore-status"></label>
+				<input type="checkbox" id="node-config-input-firestore-status" style="display:inline-block; width:15px; vertical-align:baseline;" />
+				<span data-i18n="firebase-config.useStatus">
 			</div>
 
 			<div class="firebase-text-divider" data-i18n="firebase-config.divider.storage"></div>
@@ -247,6 +262,12 @@
 			<div class="form-row">
 				<label for="node-config-input-storageBucket"><i class="fa fa-archive"></i> <span data-i18n="firebase-config.label.storageBucket"></span></label>
 				<input type="text" id="node-config-input-storageBucket" style="width:70%;" data-i18n="[placeholder]firebase-config.placeholder.storageBucket" disabled/>
+			</div>
+
+			<div class="form-row">
+				<label for="node-config-input-storage-status"></label>
+				<input type="checkbox" id="node-config-input-storage-status" style="display:inline-block; width:15px; vertical-align:baseline;" />
+				<span data-i18n="firebase-config.useStatus">
 			</div>
 		</div>
 	</div>

--- a/build/nodes/locales/en-US/firebase-config.json
+++ b/build/nodes/locales/en-US/firebase-config.json
@@ -47,6 +47,7 @@
     "createNewUser": "Create a new user if this one does not exist?",
     "addClaim": "Add Claims Set",
     "useClaims": "Use additional claims to authenticate?",
+    "useStatus": "Use the RTDB connection status?",
     "clickDragHere": "Click or drag the file here.",
     "dropFileHere": "Drop File Here",
     "nothing2complete": "Nothing to complete",

--- a/build/nodes/locales/fr/firebase-config.json
+++ b/build/nodes/locales/fr/firebase-config.json
@@ -47,6 +47,7 @@
     "createNewUser": "Créer un nouvel utilisateur si celui-ci n'existe pas ?",
     "addClaim": "Ajouter une revendication",
     "useClaims": "Utiliser d'autres revendications pour s'authentifier ?",
+    "useStatus": "Utiliser le statut de connexion de la RTDB ?",
     "clickDragHere": "Cliquer ou faites glisser le fichier ici.",
     "dropFileHere": "Lachez le fichier ici",
     "nothing2complete": "Rien à compléter",

--- a/src/lib/nodes/types/config.ts
+++ b/src/lib/nodes/types/config.ts
@@ -20,9 +20,15 @@ type AuthType = "anonymous" | "email" | "privateKey" | "customToken";
 
 type ClaimsType = Record<string, { value: string; type: "str" | "num" | "bool" | "date" | "json" }>;
 
+interface NodeStatus {
+	firestore: boolean;
+	storage: boolean;
+}
+
 export type Config = NodeDef & {
 	authType?: AuthType;
 	claims?: ClaimsType;
 	createUser?: boolean;
+	status?: NodeStatus;
 	useClaims?: boolean;
 };


### PR DESCRIPTION
Allow Firestore nodes to use RTDB connection status:

- Send status to Firestore nodes.
- Do not set global status if Firestore node does not allow it.
- Init RTDB to access connection status if no Firebase node used.