### PR TITLE
Bump for 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## 0.1.0-beta.1
+## 0.1.0
 
 ### Changes
 
@@ -11,6 +11,6 @@
 
 - Add `get`, `modify` and `subscribe` methods to Firestore (#6)
 
-## 0.0.1-beta.2
+## 0.0.1
 
 Initial version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gogovega/firebase-config-node",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gogovega/firebase-config-node",
-      "version": "0.1.0-beta.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@firebase/app": "0.10.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gogovega/firebase-config-node",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0",
   "description": "Node-RED config node to communicate with Google Firebase",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Changes

- Allow Firestore nodes to use RTDB connection status
- Bump dependencies to latest

## New Features

- Add `get`, `modify` and `subscribe` methods to Firestore