### PR TITLE
Fix Promise resolution when closing the Config Node

### DIFF
--- a/src/lib/firebase/client/client.ts
+++ b/src/lib/firebase/client/client.ts
@@ -155,7 +155,13 @@ export class Client extends TypedEmitter<ClientEvents> {
 			if (!this.admin) await signOut(this._auth!);
 		}
 
-		return this.deleteClient();
+		if (this.admin) {
+			await this.deleteClient();
+		} else {
+			// https://github.com/firebase/firebase-js-sdk/issues/7816
+			// TODO: The promise is not resolved due to a bug in Node. Workaround for now to not wait for it anymore.
+			this.deleteClient();
+		}
 	}
 
 	private async wrapSignIn(config: AppOptions): Promise<void>;


### PR DESCRIPTION
Due to a bug in Firebase JS SDK ([#7816](https://github.com/firebase/firebase-js-sdk/issues/7816)), the promise of `deleteApp` is not resolved which causes a timeout when closing the Config Node.

The temporary fix is to no longer wait for the promise to be resolved.
