### PR TITLE
Only don't wait signout for Firestore and add a safety delay

### DIFF
--- a/src/lib/firebase/client/client.ts
+++ b/src/lib/firebase/client/client.ts
@@ -163,13 +163,7 @@ export class Client extends TypedEmitter<ClientEvents> {
 			if (!this.admin) await signOut(this._auth!);
 		}
 
-		if (this.admin) {
-			await this.deleteClient();
-		} else {
-			// https://github.com/firebase/firebase-js-sdk/issues/7816
-			// TODO: The promise is not resolved due to a bug in Node. Workaround for now to not wait for it anymore.
-			this.deleteClient();
-		}
+		return this.deleteClient();
 	}
 
 	private async wrapSignIn(config: AppOptions): Promise<void>;


### PR DESCRIPTION
Rework of #10.

Since the error seems to occur only with Firestore, the RTDB can therefore wait signout.

To avoid a signin request before the signout request is complete, a small delay has been added.