### PR TITLE
Do not signout if app initialization failed

### DIFF
--- a/src/lib/firebase/client/client.ts
+++ b/src/lib/firebase/client/client.ts
@@ -154,16 +154,16 @@ export class Client extends TypedEmitter<ClientEvents> {
 		if (this.signState === SignState.NOT_YET) throw new ClientError("signOut called before signIn call");
 		if (this.signState === SignState.SIGN_OUT) throw new ClientError("signOut already called");
 
-		// The app is created regardless of whether the client has been initialized
-		// If initialized sign out, otherwise skip
+		// Ensure the app has been created to signout and delete it
 		if (this._clientInitialised) {
 			this._signState = SignState.SIGN_OUT;
 			this.emit("sign-out");
 
-			if (!this.admin) await signOut(this._auth!);
-		}
+			// Admin SDK has no signOut method - internally called during deleteApp
+			if (!this.admin && this._auth) await signOut(this._auth);
 
-		return this.deleteClient();
+			return this.deleteClient();
+		}
 	}
 
 	private async wrapSignIn(config: AppOptions): Promise<void>;
@@ -182,8 +182,8 @@ export class Client extends TypedEmitter<ClientEvents> {
 			this._signState = SignState.SIGN_IN;
 			this.emit("sign-in");
 			this._app = admin ? new AdminApp(config, this.appName) : new App(this.appConfig, this.appName);
-			this._auth = admin ? undefined : getAuth(this._app.app as FirebaseApp);
 			this._clientInitialised = true;
+			this._auth = admin ? undefined : getAuth(this._app.app as FirebaseApp);
 			const user = await signInFn();
 			this._signState = SignState.SIGNED_IN;
 			success = true;

--- a/src/lib/firebase/client/client.ts
+++ b/src/lib/firebase/client/client.ts
@@ -155,7 +155,7 @@ export class Client extends TypedEmitter<ClientEvents> {
 		if (this.signState === SignState.SIGN_OUT) throw new ClientError("signOut already called");
 
 		// Ensure the app has been created to signout and delete it
-		if (this._clientInitialised) {
+		if (this._app) {
 			this._signState = SignState.SIGN_OUT;
 			this.emit("sign-out");
 
@@ -181,13 +181,35 @@ export class Client extends TypedEmitter<ClientEvents> {
 		try {
 			this._signState = SignState.SIGN_IN;
 			this.emit("sign-in");
-			this._app = admin ? new AdminApp(config, this.appName) : new App(this.appConfig, this.appName);
-			this._clientInitialised = true;
-			this._auth = admin ? undefined : getAuth(this._app.app as FirebaseApp);
-			const user = await signInFn();
-			this._signState = SignState.SIGNED_IN;
-			success = true;
-			return user;
+
+			if (!admin) {
+				// Initialize the app
+				this._app = new App(this.appConfig, this.appName);
+
+				// Validate the API Key
+				this._auth = getAuth(this._app.app);
+
+				// The client is ready to init DB
+				this._clientInitialised = true;
+
+				// Starting sign in
+				const user = await signInFn();
+
+				// Signed in
+				this._signState = SignState.SIGNED_IN;
+				success = true;
+				return user;
+			} else {
+				// Initialize the app and sign in
+				this._app = new AdminApp(config, this.appName);
+
+				// The client is ready to init DB
+				this._clientInitialised = true;
+
+				// Signed in
+				this._signState = SignState.SIGNED_IN;
+				success = true;
+			}
 		} finally {
 			if (!success) this._signState = SignState.ERROR;
 			this.emit(success ? "signed-in" : "sign-in-error");

--- a/src/lib/nodes/firebase-client.ts
+++ b/src/lib/nodes/firebase-client.ts
@@ -343,11 +343,13 @@ export class FirebaseClient {
 	public logOut(done: () => void) {
 		(async () => {
 			try {
+				// Remove listeners
 				this.disableConnectionHandler();
 				this.disableGlobalLogHandler();
 
-				// Do not signout if the client is not initialized
-				if (!this.node.client?.clientInitialised) return done();
+				// Skip logout if the app has not been created
+				if (!this.node.client) return done();
+				if (!this.node.client.app) return done();
 
 				const rtdbOnline = this.node.rtdb && !this.node.rtdb.offline;
 				const firestoreOnline = this.node.firestore && !this.node.firestore.offline;


### PR DESCRIPTION
Resolves the second part of https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/discussions/77.

If the application failed to initialize, signin was not called and therefore do not signout.

Also fixes an edge case where the client was not created and ignores logout resulting in listeners not being removed.