### PR TITLE
Allow UI to set the RTDB `defaultWriteSizeLimit` setting

### DIFF
--- a/build/nodes/firebase-config.html
+++ b/build/nodes/firebase-config.html
@@ -95,6 +95,7 @@
 					],
 				});
 
+				const node = this;
 				let popover = null;
 				const sizeLimitButton = $("#node-config-button-defaultWriteSizeLimit");
 				sizeLimitButton.on("click", function (event) {
@@ -104,8 +105,7 @@
 					if ($(this).attr("disabled")) return;
 					$(this).attr("disabled", true);
 
-					const that = this;
-					$.post(`firebase/config-node/rtdb/settings/${this.id}`, { writeSizeLimit: sizeLimitInput.val() })
+					$.post(`firebase/config-node/rtdb/settings/${node.id}`, { writeSizeLimit: sizeLimitInput.val() })
 						.then(function () {
 							RED.notify("Successfully updated RTDB settings", "success");
 						})
@@ -114,7 +114,7 @@
 							RED.notify("Failed to update RTDB settings", "error");
 						})
 						.always(function () {
-							$(that).attr("disabled", false);
+							sizeLimitButton.attr("disabled", false);
 						});
 				});
 
@@ -125,8 +125,8 @@
 						popover?.delete();
 						popover = null;
 
-						$.getJSON(`firebase/config-node/rtdb/settings/${this.id}`, function (response) {
-							sizeLimitInput.typedInput("value", response.defaultWriteSizeLimit);
+						$.getJSON(`firebase/config-node/rtdb/settings/${node.id}`, function (response) {
+							sizeLimitInput.typedInput("value", response.defaultWriteSizeLimit || "large");
 						});
 					} else if (popover) {
 						sizeLimitButton.attr("disabled", true);

--- a/build/nodes/firebase-config.html
+++ b/build/nodes/firebase-config.html
@@ -80,6 +80,63 @@
 				// deprecated
 				$("#node-config-input-json").typedInput({ default: "json", types: ["json"] });
 
+				const timeMap = { small: 10, medium: 30, large: 60 };
+				const sizeLimitInput = $("#node-config-input-defaultWriteSizeLimit");
+				sizeLimitInput.typedInput({
+					type: "size",
+					types: [
+						{
+							value: "size", // TODO: i18n
+							options: ["small", "medium", "large", "unlimited"].map((o) => ({
+								value: o,
+								label: o + (timeMap[o] ? ` (${timeMap[o]}s)` : ""),
+							})),
+						},
+					],
+				});
+
+				let popover = null;
+				const sizeLimitButton = $("#node-config-button-defaultWriteSizeLimit");
+				sizeLimitButton.on("click", function (event) {
+					event.preventDefault();
+					event.stopPropagation();
+
+					if ($(this).attr("disabled")) return;
+					$(this).attr("disabled", true);
+
+					const that = this;
+					$.post(`firebase/config-node/rtdb/settings/${this.id}`, { writeSizeLimit: sizeLimitInput.val() })
+						.then(function () {
+							RED.notify("Successfully updated RTDB settings", "success");
+						})
+						.fail(function (error) {
+							console.warn(error.statusText, error.responseText);
+							RED.notify("Failed to update RTDB settings", "error");
+						})
+						.always(function () {
+							$(that).attr("disabled", false);
+						});
+				});
+
+				const msg = "Only available with PrivateKey authentication";
+				authType.on("change", function () {
+					if (authType.val() === "privateKey") {
+						sizeLimitButton.attr("disabled", false);
+						popover?.delete();
+						popover = null;
+
+						$.getJSON(`firebase/config-node/rtdb/settings/${this.id}`, function (response) {
+							sizeLimitInput.typedInput("value", response.defaultWriteSizeLimit);
+						});
+					} else if (popover) {
+						sizeLimitButton.attr("disabled", true);
+						popover.setContent(msg);
+					} else {
+						sizeLimitButton.attr("disabled", true);
+						popover = RED.popover.tooltip(sizeLimitButton, msg);
+					}
+				});
+
 				const tabs = RED.tabs.create({
 					id: "node-config-firebase-tabs",
 					onchange: function (tab) {
@@ -101,6 +158,11 @@
 				tabs.addTab({
 					id: "firebase-tab-databases",
 					label: this._("firebase-config.tabs.databases"),
+				});
+
+				tabs.addTab({
+					id: "firebase-tab-settings",
+					label: this._("firebase-config.tabs.settings"),
 				});
 
 				tabs.activateTab("firebase-tab-connection");
@@ -268,6 +330,22 @@
 				<label for="node-config-input-storage-status"></label>
 				<input type="checkbox" id="node-config-input-storage-status" style="display:inline-block; width:15px; vertical-align:baseline;" />
 				<span data-i18n="firebase-config.useStatus">
+			</div>
+		</div>
+
+		<!-- Settings Tab -->
+		<div id="firebase-tab-settings" style="display:none;">
+			<div class="firebase-text-divider" data-i18n="firebase-config.divider.rtdb"></div>
+
+			<div class="form-row" style="display: flex; align-items: center;">
+				<label for="node-config-input-defaultWriteSizeLimit"><i class="fa fa-cogs"></i> <span data-i18n="firebase-config.label.writeSizeLimit"></span></label>
+				<div style="width: 70%; display: inline-flex; align-items: center;">
+					<div style="flex-grow: 1;">
+						<input id="node-config-input-defaultWriteSizeLimit" style="width: 100%;"/>
+					</div>
+					<button id="node-config-button-defaultWriteSizeLimit" class="red-ui-button red-ui-button-small" style="width: auto; margin-left: 10px;"><span data-i18n="firebase-config.saveSetting"></span></button>
+				</div>
+				<div title="Link to Firebase documentation" style="margin-left: 10px;"><a href="https://firebase.google.com/docs/reference/rest/database?hl=en-us#section-param-writesizelimit"><i class="fa fa-external-link-square"></i></a></div>
 			</div>
 		</div>
 	</div>

--- a/build/nodes/locales/en-US/firebase-config.json
+++ b/build/nodes/locales/en-US/firebase-config.json
@@ -13,12 +13,14 @@
       "projectId": "Project ID",
       "storageBucket": "Bucket",
       "uid": "UID",
-      "url": "URL"
+      "url": "URL",
+      "writeSizeLimit": "Write size limit"
     },
     "tabs": {
       "connection": "Connection",
       "security": "Security",
-      "databases": "Databases"
+      "databases": "Databases",
+      "settings": "Settings"
     },
     "divider": {
       "authMethod": "Authentication Method",
@@ -51,6 +53,7 @@
     "clickDragHere": "Click or drag the file here.",
     "dropFileHere": "Drop File Here",
     "nothing2complete": "Nothing to complete",
+    "saveSetting": "Save setting",
     "tooltips": {
       "apiKey": "<strong>API Key</strong> can be found in the project settings.",
       "clientEmail": "<strong>Client Email</strong> can be found in the JSON file, it is the <strong>client_email</strong> field.",

--- a/build/nodes/locales/fr/firebase-config.json
+++ b/build/nodes/locales/fr/firebase-config.json
@@ -13,12 +13,14 @@
       "projectId": "ID Projet",
       "storageBucket": "Bucket",
       "uid": "UID",
-      "url": "URL"
+      "url": "URL",
+      "writeSizeLimit": "Taille max d'écriture"
     },
     "tabs": {
       "connection": "Connexion",
       "security": "Sécurité",
-      "databases": "Base de données"
+      "databases": "Base de données",
+      "settings": "Paramètres"
     },
     "divider": {
       "authMethod": "Méthode d'authentification",
@@ -51,6 +53,7 @@
     "clickDragHere": "Cliquer ou faites glisser le fichier ici.",
     "dropFileHere": "Lachez le fichier ici",
     "nothing2complete": "Rien à compléter",
+    "saveSetting": "Enregistrer le paramètre",
     "tooltips": {
       "apiKey": "La <strong>Clé API</strong> se trouve dans les paramètres du projet.",
       "clientEmail": "L'<strong>Email Client</strong> peut être trouvée dans la console Firebase, dans la section <strong>Paramètres du projet</strong>, cliquez sur <strong>Comptes de service</strong> puis sur <strong>Clés de compte de service</strong>. L'adresse e-mail est affichée dans la colonne <strong>Adresse e-mail</strong>.",

--- a/src/lib/firebase/client/utils.ts
+++ b/src/lib/firebase/client/utils.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { ServiceAccount, cert } from "firebase-admin/app";
+import { GoogleOAuthAccessToken, ServiceAccount, cert } from "firebase-admin/app";
 import { getAuth } from "firebase-admin/auth";
 import { claimsNotAllowed } from "./constants";
 import { Credentials, ServiceAccountId } from "./types";
@@ -56,4 +56,8 @@ async function createCustomToken(cred: Credentials, uid: string, claims?: object
 	return token;
 }
 
-export { checkJSONCredential, createCustomToken };
+function getAccessToken(serviceAccount: ServiceAccount): Promise<GoogleOAuthAccessToken> {
+	return cert(checkJSONCredential(serviceAccount)).getAccessToken();
+}
+
+export { checkJSONCredential, createCustomToken, getAccessToken };

--- a/src/lib/nodes/rtdb-settings.ts
+++ b/src/lib/nodes/rtdb-settings.ts
@@ -75,14 +75,13 @@ async function updateDatabaseSettings(RED: NodeAPI, got: typeof import("got").go
 		const url = `${databaseURL}.settings/${path}.json`;
 		const writeSizeLimit = req.body.writeSizeLimit;
 
-		const response = await got.post(url, {
+		await got.put(url, {
 			headers: { Authorization: `Bearer ${token?.access_token}` },
 			body: JSON.stringify(writeSizeLimit),
 			responseType: "json",
 		});
 
-		res.status(200);
-		console.log(response.body);
+		res.sendStatus(200);
 	} catch (error) {
 		res.status(500).send({ message: String(error) });
 		RED.log.error("An error occured while setting RTDB settings: ");

--- a/src/lib/nodes/rtdb-settings.ts
+++ b/src/lib/nodes/rtdb-settings.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2023 Gauthier Dandele
+ *
+ * Licensed under the MIT License,
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/MIT.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Request, Response } from "express";
+import { ConfigNode } from "./types";
+import { NodeAPI } from "node-red";
+import { isFirebaseConfigNode } from "../firebase/utils";
+
+async function getDatabaseSettings(RED: NodeAPI, got: typeof import("got").got, req: Request, res: Response) {
+	try {
+		const id = req.params.id;
+
+		if (!id) {
+			res.status(400).send("The config-node ID is missing!");
+			return;
+		}
+
+		const node = RED.nodes.getNode(id) as ConfigNode | null;
+		if (!node || !isFirebaseConfigNode(node) || !node.client) {
+			res.json({});
+			return;
+		}
+
+		const databaseURL = node.credentials.url;
+		const token = await node.client.getAccessToken();
+
+		const path = encodeURI(req.body.path || "defaultWriteSizeLimit");
+		const url = `${databaseURL}.settings/${path}.json`;
+
+		const response = await got.get(url, {
+			headers: { Authorization: `Bearer ${token?.access_token}` },
+			responseType: "json",
+		});
+
+		res.json({ defaultWriteSizeLimit: response.body });
+	} catch (error) {
+		res.status(500).send({ message: String(error) });
+		RED.log.error("An error occured while getting RTDB settings: ");
+		RED.log.error(error);
+	}
+}
+
+async function updateDatabaseSettings(RED: NodeAPI, got: typeof import("got").got, req: Request, res: Response) {
+	try {
+		const id = req.params.id;
+
+		if (!id) {
+			res.status(400).send("The config-node ID is missing!");
+			return;
+		}
+
+		const node = RED.nodes.getNode(id) as ConfigNode | null;
+		if (!node || !isFirebaseConfigNode(node) || !node.client) {
+			res.status(400).send("Config Node disabled or not yet deployed");
+			return;
+		}
+
+		const databaseURL = node.credentials.url;
+		const token = await node.client.getAccessToken();
+
+		const path = encodeURI(req.body.path || "defaultWriteSizeLimit");
+		const url = `${databaseURL}.settings/${path}.json`;
+		const writeSizeLimit = req.body.writeSizeLimit;
+
+		const response = await got.post(url, {
+			headers: { Authorization: `Bearer ${token?.access_token}` },
+			body: JSON.stringify(writeSizeLimit),
+			responseType: "json",
+		});
+
+		res.status(200);
+		console.log(response.body);
+	} catch (error) {
+		res.status(500).send({ message: String(error) });
+		RED.log.error("An error occured while setting RTDB settings: ");
+		RED.log.error(error);
+	}
+}
+
+export { getDatabaseSettings, updateDatabaseSettings };

--- a/src/nodes/firebase-config.ts
+++ b/src/nodes/firebase-config.ts
@@ -15,12 +15,13 @@
  */
 
 import { NodeAPI } from "node-red";
+import { getDatabaseSettings, updateDatabaseSettings } from "../lib/nodes/rtdb-settings";
 import { FirebaseClient } from "../lib/nodes/firebase-client";
 import { Config, ConfigNode } from "../lib/nodes/types";
 
 const VERSION = "0.2.1";
 
-export default function (RED: NodeAPI) {
+export default async function (RED: NodeAPI) {
 	/**
 	 * Firebase Configuration Node
 	 *
@@ -63,4 +64,21 @@ export default function (RED: NodeAPI) {
 			url: { type: "text" },
 		},
 	});
+
+	// Got need a dynamic import due to ESM
+	// Dynamic imports are transpiled when module is CommonJS
+	// https://github.com/microsoft/TypeScript/issues/43329
+	const got = (await new Function("return import('got')")()).got;
+
+	RED.httpAdmin.get(
+		"/firebase/config-node/rtdb/settings/:id",
+		RED.auth.needsPermission("firebase-config.write"),
+		(req, res) => getDatabaseSettings(RED, got, req, res)
+	);
+
+	RED.httpAdmin.post(
+		"/firebase/config-node/rtdb/settings/:id",
+		RED.auth.needsPermission("firebase-config.write"),
+		(req, res) => updateDatabaseSettings(RED, got, req, res)
+	);
 }


### PR DESCRIPTION
Closes https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/discussions/73.

A new `Settings` tab has been added. This new tab contains a select input that defines the maximum writing size (`defaultWriteSizeLimit`) of RTDB.

The number in parentheses is the maximum time a write operation has to be done before being interrupted.

<img width="649" src="https://github.com/user-attachments/assets/8758aaf0-3ede-4f62-bd85-3cc2b52c2331" />

To use it:

1. Select the size
2. Click on `Save setting`

> [!IMPORTANT]
> Only available for the `Private Key` authentication