### PR TITLE
Support for `addDoc` to create a doc with auto-generated id

### DIFF
--- a/src/lib/firebase/firestore/firestore.ts
+++ b/src/lib/firebase/firestore/firestore.ts
@@ -17,12 +17,14 @@
 
 import { App } from "firebase-admin/app";
 import {
+	type CollectionReference as AdminCollectionReference,
 	getFirestore as adminGetFirestore,
 	SetOptions,
 	type Firestore as AdminDatabase,
 } from "firebase-admin/firestore";
 import { FirebaseApp } from "@firebase/app";
 import {
+	addDoc,
 	getFirestore,
 	Firestore as Database,
 	disableNetwork,
@@ -34,6 +36,7 @@ import {
 	setDoc,
 	updateDoc,
 	deleteDoc,
+	type CollectionReference,
 } from "@firebase/firestore";
 
 import { FirestoreError } from "./error";
@@ -136,7 +139,16 @@ export class Firestore {
 			case "set":
 				if (!value || typeof value !== "object") throw new TypeError("Value to write must be an object");
 				if (this.isAdmin(this._database)) {
+					if (!config.document) {
+						// Create a doc with id auto-generated and the specified value
+						return documentFrom<AdminCollectionReference>(this._database, config).add(value);
+					}
 					return documentFrom(this._database, config).set(value, options);
+				}
+
+				if (!config.document) {
+					// Create a doc with id auto-generated and the specified value
+					return addDoc(documentFrom<CollectionReference>(this._database, config), value);
 				}
 				return setDoc(documentFrom(this._database, config), value, options);
 			case "update":

--- a/src/lib/firebase/firestore/utils.ts
+++ b/src/lib/firebase/firestore/utils.ts
@@ -172,12 +172,18 @@ function isAdminFirestore(firestore: AdminFirestore | Firestore): firestore is A
 	return "settings" in firestore && "databaseId" in firestore;
 }
 
-function documentFrom(firestore: AdminFirestore, config: QueryConfig): AdminDocumentReference;
-function documentFrom(firestore: Firestore, config: QueryConfig): DocumentReference;
+function documentFrom<T extends AdminDocumentReference | AdminCollectionReference = AdminDocumentReference>(
+	firestore: AdminFirestore,
+	config: QueryConfig
+): T;
+function documentFrom<T extends DocumentReference | CollectionReference = DocumentReference>(
+	firestore: Firestore,
+	config: QueryConfig
+): T;
 function documentFrom(
 	firestore: AdminFirestore | Firestore,
 	config: QueryConfig
-): AdminDocumentReference | DocumentReference {
+): AdminCollectionReference | AdminDocumentReference | CollectionReference | DocumentReference {
 	let reference;
 
 	if (config.collection) {
@@ -199,9 +205,11 @@ function documentFrom(
 				: firestore.doc(config.document);
 		}
 		return reference instanceof CollectionReference ? doc(reference, config.document) : doc(firestore, config.document);
-	} else {
-		throw new Error("DocumentPath missing for Document reference.");
 	}
+
+	if (!reference) throw new Error("Path missing to Collection/Document reference.");
+
+	return reference;
 }
 
 function queryFrom(firestore: AdminFirestore, config: QueryConfig): AdminDocumentReference | AdminQuery;


### PR DESCRIPTION
The `set` method of `Firestore.modify` can now accept an empty document path which will generate an id automatically.