### PR TITLE
Fix RTDB URL pattern

### DIFF
--- a/resources/common.js
+++ b/resources/common.js
@@ -74,7 +74,7 @@ const FirebaseConfigUI = (function () {
           const storageStatus = $("#node-config-input-storage-status").prop("checked") ?? this.status?.storage;
           if (firestoreStatus || storageStatus) return opt ? i18n("validators.missing-url") : false;
         }
-        if (/^$|^https:\/\/[a-zA-Z0-9-]{4,30}-default-rtdb\.((asia-southeast1|europe-west1)\.firebasedatabase\.app|firebaseio\.com)\/$/.test(value)) return true;
+        if (/^$|^https:\/\/[a-zA-Z0-9-]{4,63}(-default-rtdb)?\.((asia-southeast1|europe-west1)\.firebasedatabase\.app|firebaseio\.com)\/$/.test(value)) return true;
         return opt ? i18n("validators.invalid-url") : false;
       };
     },


### PR DESCRIPTION
Fixes #29.

After extensive research trying to find any documentation on the realtime database URL pattern, I have come to the following conclusion:

- For the first database, the pattern is `https://<project-id>-default-rtdb.firebaseio.com` or `https://<project-id>-default-rtdb.<location>.firebasedatabase.app`
  - `project-id` has a length of 4 to 30
- For other databases, the pattern is `https://<custom-reference>.firebaseio.com` or `https://<project-id>.<location>.firebasedatabase.app`
  - `custom-reference` has a maximum length of 63

Source: https://firebase.google.com/docs/database/usage/sharding