### PR TITLE
Improves the logic around `defaultWriteSizeLimit`

### DIFF
--- a/build/nodes/firebase-config.html
+++ b/build/nodes/firebase-config.html
@@ -132,19 +132,23 @@
 						});
 				});
 
+				let isPrivateKeyAuthUsed = false;
+				$.getJSON(`firebase/config-node/rtdb/settings/${this.id}`, function (response) {
+					if (response.defaultWriteSizeLimit) {
+						// Assume the runtime uses PrivateKey authentication to obtain a non-empty value
+						isPrivateKeyAuthUsed = true;
+					}
+					sizeLimitInput.typedInput("value", response.defaultWriteSizeLimit || "large");
+					authType.trigger("change");
+				});
+
 				let popover = null;
 				const msg = "Only available with PrivateKey authentication";
-				const deployedNode = RED.nodes.node(this.id) || this;
 				authType.on("change", function () {
-					if (deployedNode._config && deployedNode._config.authType === "privateKey") {
-						// Allow the action as long as the runtime-side node is running with a private key
+					if (isPrivateKeyAuthUsed) {
 						sizeLimitButton.attr("disabled", false);
 						popover?.delete();
 						popover = null;
-
-						$.getJSON(`firebase/config-node/rtdb/settings/${node.id}`, function (response) {
-							sizeLimitInput.typedInput("value", response.defaultWriteSizeLimit || "large");
-						});
 					} else if (authType.val() === "privateKey") {
 						sizeLimitButton.attr("disabled", true);
 						const msg = "Deploy your changes first";


### PR DESCRIPTION
In #49, the logic allowing the parameter to be written was based on the configuration loaded by the editor. The issue is that deploying changes does not update this configuration; a user can deploy a config node with a different authentication method without the node being aware that the configuration has changed.

With this PR, when the edit dialog opens, the parameter is loaded.
- If it exists, the runtime uses the PrivateKey method.
- If it does not exist, the user must first deploy their changes before proceeding.